### PR TITLE
Removed namespaced tf_static

### DIFF
--- a/clearpath_generator_gz/clearpath_generator_gz/launch/generator.py
+++ b/clearpath_generator_gz/clearpath_generator_gz/launch/generator.py
@@ -166,25 +166,6 @@ class GzLaunchGenerator(LaunchGenerator):
           ]
         )
 
-        # Static transform from <namespace>/odom to odom
-        # See https://github.com/ros-controls/ros2_controllers/pull/533
-        self.tf_namespaced_odom_publisher = LaunchFile.get_static_tf_node(
-            name='namespaced_odom',
-            namespace=self.namespace,
-            parent_link='odom',
-            child_link=self.namespace + '/odom',
-            use_sim_time=True
-        )
-
-        # Static transform from <namespace>/base_link to base_link
-        self.tf_namespaced_base_link_publisher = LaunchFile.get_static_tf_node(
-            name='namespaced_base_link',
-            namespace=self.namespace,
-            parent_link=self.namespace + '/base_link',
-            child_link='base_link',
-            use_sim_time=True
-        )
-
         # Components required for each platform
         self.platform_components = {
             Platform.J100: [
@@ -281,8 +262,6 @@ class GzLaunchGenerator(LaunchGenerator):
         for component in self.platform_components[self.platform_model]:
             platform_service_launch_writer.add(component)
 
-        if self.namespace not in ('', '/'):
-            platform_service_launch_writer.add(self.tf_namespaced_odom_publisher)
-            platform_service_launch_writer.add(self.tf_namespaced_base_link_publisher)
+        print("NEW")
 
         platform_service_launch_writer.generate_file()

--- a/clearpath_generator_gz/clearpath_generator_gz/launch/generator.py
+++ b/clearpath_generator_gz/clearpath_generator_gz/launch/generator.py
@@ -262,6 +262,4 @@ class GzLaunchGenerator(LaunchGenerator):
         for component in self.platform_components[self.platform_model]:
             platform_service_launch_writer.add(component)
 
-        print("NEW")
-
         platform_service_launch_writer.generate_file()


### PR DESCRIPTION
The changes in https://github.com/ros-controls/ros2_controllers/commit/6ca402680b88cea90916ef3f350c668ae6abfc35 now let us avoid namespacing links. 