### PR TITLE
Play sim automatically

### DIFF
--- a/clearpath_gz/launch/gz_sim.launch.py
+++ b/clearpath_gz/launch/gz_sim.launch.py
@@ -66,6 +66,7 @@ def generate_launch_description():
         launch_arguments=[
             ('gz_args', [LaunchConfiguration('world'),
                          '.sdf',
+                         ' -r',
                          ' -v 4',
                          ' --gui-config ',
                          gui_config])

--- a/clearpath_gz/launch/gz_sim.launch.py
+++ b/clearpath_gz/launch/gz_sim.launch.py
@@ -19,7 +19,7 @@ import os
 from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
+from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.actions import IncludeLaunchDescription, SetEnvironmentVariable
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
@@ -32,7 +32,46 @@ ARGUMENTS = [
                           description='use_sim_time'),
     DeclareLaunchArgument('world', default_value='warehouse',
                           description='Gazebo World'),
+    DeclareLaunchArgument('auto_start', default_value='true',
+                          choices=['true', 'false'],
+                          description='Auto-start Gazebo simulation'),
 ]
+
+
+def gz_launch(context, *args, **kwargs):
+
+    # Directories
+    pkg_clearpath_gz = get_package_share_directory(
+        'clearpath_gz')
+    pkg_ros_gz_sim = get_package_share_directory(
+        'ros_gz_sim')
+
+    # Paths
+    gz_sim_launch = PathJoinSubstitution(
+        [pkg_ros_gz_sim, 'launch', 'gz_sim.launch.py'])
+
+    gui_config = PathJoinSubstitution(
+        [pkg_clearpath_gz, 'config', 'gui.config'])
+
+    auto_start_option = ''
+    auto_start = LaunchConfiguration('auto_start').perform(context)
+    if (auto_start == 'true'):
+        auto_start_option = ' -r'
+
+    # Gazebo Simulator
+    gz_sim = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([gz_sim_launch]),
+        launch_arguments=[
+            ('gz_args', [LaunchConfiguration('world'),
+                         '.sdf',
+                         auto_start_option,
+                         ' -v 4',
+                         ' --gui-config ',
+                         gui_config])
+        ]
+    )
+
+    return [gz_sim]
 
 
 def generate_launch_description():
@@ -40,8 +79,6 @@ def generate_launch_description():
     # Directories
     pkg_clearpath_gz = get_package_share_directory(
         'clearpath_gz')
-    pkg_ros_gz_sim = get_package_share_directory(
-        'ros_gz_sim')
 
     # Determine all ros packages that are sourced
     packages_paths = [os.path.join(p, 'share') for p in os.getenv('AMENT_PREFIX_PATH').split(':')]
@@ -52,26 +89,6 @@ def generate_launch_description():
         value=[
             os.path.join(pkg_clearpath_gz, 'worlds'),
             ':' + ':'.join(packages_paths)])
-
-    # Paths
-    gz_sim_launch = PathJoinSubstitution(
-        [pkg_ros_gz_sim, 'launch', 'gz_sim.launch.py'])
-
-    gui_config = PathJoinSubstitution(
-        [pkg_clearpath_gz, 'config', 'gui.config'])
-
-    # Gazebo Simulator
-    gz_sim = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([gz_sim_launch]),
-        launch_arguments=[
-            ('gz_args', [LaunchConfiguration('world'),
-                         '.sdf',
-                         ' -r',
-                         ' -v 4',
-                         ' --gui-config ',
-                         gui_config])
-        ]
-    )
 
     # Clock bridge
     clock_bridge = Node(package='ros_gz_bridge',
@@ -85,6 +102,6 @@ def generate_launch_description():
     # Create launch description and add actions
     ld = LaunchDescription(ARGUMENTS)
     ld.add_action(gz_sim_resource_path)
-    ld.add_action(gz_sim)
+    ld.add_action(OpaqueFunction(function=gz_launch))
     ld.add_action(clock_bridge)
     return ld


### PR DESCRIPTION
Fixes https://github.com/clearpathrobotics/clearpath_simulator/issues/46, https://github.com/clearpathrobotics/clearpath_simulator/issues/50

This change is in reaction to the following PR: https://github.com/ros-controls/ros2_control/pull/1659 where a timeout is added for the switch controller service. This timeout is hardcoded as 5 seconds here: https://github.com/ros-controls/ros2_control/blob/8779757f7e5cdb5e6998d9b162e65015003e3c1f/controller_manager/controller_manager/spawner.py#L332 

Further discussion should be had on proposing to parameterize that timeout so that we can adapt for low resource sims which are slow to launch and/or making the timeout based on ROS time. 