### PR TITLE
Rename Gazbo libraries

### DIFF
--- a/clearpath_generator_gz/clearpath_generator_gz/launch/generator.py
+++ b/clearpath_generator_gz/clearpath_generator_gz/launch/generator.py
@@ -41,9 +41,9 @@ from clearpath_generator_gz.launch.sensors import SensorLaunch
 
 
 class GzLaunchGenerator(LaunchGenerator):
-    GZ_TO_ROS_TWIST = '@geometry_msgs/msg/Twist[ignition.msgs.Twist'
-    ROS_TO_GZ_TWIST = '@geometry_msgs/msg/Twist]ignition.msgs.Twist'
-    GZ_TO_ROS_TF = '@tf2_msgs/msg/TFMessage[ignition.msgs.Pose_V'
+    GZ_TO_ROS_TWIST = '@geometry_msgs/msg/TwistStamped[gz.msgs.Twist'
+    ROS_TO_GZ_TWIST = '@geometry_msgs/msg/TwistStamped]gz.msgs.Twist'
+    GZ_TO_ROS_TF = '@tf2_msgs/msg/TFMessage[gz.msgs.Pose_V'
 
     def __init__(self, setup_path: str = '/etc/clearpath/') -> None:
         super().__init__(setup_path)
@@ -70,7 +70,7 @@ class GzLaunchGenerator(LaunchGenerator):
         cmd_vel_robot_bridge_arg = '/model/' + self.robot_name + '/cmd_vel' + self.ROS_TO_GZ_TWIST
         cmd_vel_robot_bridge_remap = (
             '/model/' + self.robot_name + '/cmd_vel',
-            'platform/cmd_vel_unstamped'
+            'platform/cmd_vel'
           )
 
         self.cmd_vel_node = LaunchFile.Node(

--- a/clearpath_generator_gz/clearpath_generator_gz/launch/sensors.py
+++ b/clearpath_generator_gz/clearpath_generator_gz/launch/sensors.py
@@ -48,12 +48,12 @@ class SensorLaunch():
     NAMESPACE = 'namespace'
 
     # gz to ros bridge parameters
-    GZ_TO_ROS_LASERSCAN = '@sensor_msgs/msg/LaserScan[ignition.msgs.LaserScan'
-    GZ_TO_ROS_POINTCLOUD = '@sensor_msgs/msg/PointCloud2[ignition.msgs.PointCloudPacked'
-    GZ_TO_ROS_IMAGE = '@sensor_msgs/msg/Image[ignition.msgs.Image'
-    GZ_TO_ROS_CAMERA_INFO = '@sensor_msgs/msg/CameraInfo[ignition.msgs.CameraInfo'
-    GZ_TO_ROS_IMU = '@sensor_msgs/msg/Imu[ignition.msgs.IMU'
-    GZ_TO_ROS_NAVSAT = '@sensor_msgs/msg/NavSatFix[ignition.msgs.NavSat'
+    GZ_TO_ROS_LASERSCAN = '@sensor_msgs/msg/LaserScan[gz.msgs.LaserScan'
+    GZ_TO_ROS_POINTCLOUD = '@sensor_msgs/msg/PointCloud2[gz.msgs.PointCloudPacked'
+    GZ_TO_ROS_IMAGE = '@sensor_msgs/msg/Image[gz.msgs.Image'
+    GZ_TO_ROS_CAMERA_INFO = '@sensor_msgs/msg/CameraInfo[gz.msgs.CameraInfo'
+    GZ_TO_ROS_IMU = '@sensor_msgs/msg/Imu[gz.msgs.IMU'
+    GZ_TO_ROS_NAVSAT = '@sensor_msgs/msg/NavSatFix[gz.msgs.NavSat'
 
     RGBD_CAMERAS = [
         IntelRealsense.SENSOR_MODEL,

--- a/clearpath_gz/config/gui.config
+++ b/clearpath_gz/config/gui.config
@@ -13,7 +13,7 @@
     </menus>
 </window>
 <plugin filename="MinimalScene" name="3D View">
-    <ignition-gui>
+    <gz-gui>
         <title>3D View</title>
         <property key="x" type="double">0</property>
         <property key="y" type="double">0</property>
@@ -79,7 +79,7 @@
         <property key="cardMinimumHeight" type="int">200</property>
         <property key="pluginToolBarColor" type="string">#bbdefb</property>
         <property key="pluginToolBarTextColor" type="string">#111111</property>
-    </ignition-gui>
+    </gz-gui>
     <engine>ogre2</engine>
     <scene>scene</scene>
     <ambient_light>0.4 0.4 0.4</ambient_light>
@@ -87,7 +87,7 @@
     <camera_pose>-6 0 6 0 0.5 0</camera_pose>
 </plugin>
 <plugin filename="EntityContextMenuPlugin" name="Entity context menu">
-    <ignition-gui>
+    <gz-gui>
         <property key="x" type="double">0</property>
         <property key="y" type="double">0</property>
         <property key="z" type="double">0</property>
@@ -152,10 +152,10 @@
         <property key="cardMinimumHeight" type="int">370</property>
         <property key="pluginToolBarColor" type="string">#bbdefb</property>
         <property key="pluginToolBarTextColor" type="string">#111111</property>
-    </ignition-gui>
+    </gz-gui>
 </plugin>
 <plugin filename="GzSceneManager" name="Scene Manager">
-    <ignition-gui>
+    <gz-gui>
         <property key="x" type="double">0</property>
         <property key="y" type="double">0</property>
         <property key="z" type="double">0</property>
@@ -220,10 +220,10 @@
         <property key="cardMinimumHeight" type="int">130</property>
         <property key="pluginToolBarColor" type="string">#bbdefb</property>
         <property key="pluginToolBarTextColor" type="string">#111111</property>
-    </ignition-gui>
+    </gz-gui>
 </plugin>
 <plugin filename="InteractiveViewControl" name="Interactive view control">
-    <ignition-gui>
+    <gz-gui>
         <property key="x" type="double">0</property>
         <property key="y" type="double">0</property>
         <property key="z" type="double">0</property>
@@ -288,10 +288,10 @@
         <property key="cardMinimumHeight" type="int">110</property>
         <property key="pluginToolBarColor" type="string">#bbdefb</property>
         <property key="pluginToolBarTextColor" type="string">#111111</property>
-    </ignition-gui>
+    </gz-gui>
 </plugin>
 <plugin filename="CameraTracking" name="Camera Tracking">
-    <ignition-gui>
+    <gz-gui>
         <property key="x" type="double">0</property>
         <property key="y" type="double">0</property>
         <property key="z" type="double">0</property>
@@ -356,10 +356,10 @@
         <property key="cardMinimumHeight" type="int">260</property>
         <property key="pluginToolBarColor" type="string">#bbdefb</property>
         <property key="pluginToolBarTextColor" type="string">#111111</property>
-    </ignition-gui>
+    </gz-gui>
 </plugin>
 <plugin filename="MarkerManager" name="Marker manager">
-    <ignition-gui>
+    <gz-gui>
         <property key="x" type="double">0</property>
         <property key="y" type="double">0</property>
         <property key="z" type="double">0</property>
@@ -424,10 +424,10 @@
         <property key="cardMinimumHeight" type="int">230</property>
         <property key="pluginToolBarColor" type="string">#bbdefb</property>
         <property key="pluginToolBarTextColor" type="string">#111111</property>
-    </ignition-gui>
+    </gz-gui>
 </plugin>
 <plugin filename="SelectEntities" name="Select Entities">
-    <ignition-gui>
+    <gz-gui>
         <property key="x" type="double">0</property>
         <property key="y" type="double">0</property>
         <property key="z" type="double">0</property>
@@ -492,10 +492,10 @@
         <property key="cardMinimumHeight" type="int">90</property>
         <property key="pluginToolBarColor" type="string">#bbdefb</property>
         <property key="pluginToolBarTextColor" type="string">#111111</property>
-    </ignition-gui>
+    </gz-gui>
 </plugin>
 <plugin filename="Spawn" name="Spawn Entities">
-    <ignition-gui>
+    <gz-gui>
         <property key="x" type="double">0</property>
         <property key="y" type="double">0</property>
         <property key="z" type="double">0</property>
@@ -560,10 +560,10 @@
         <property key="cardMinimumHeight" type="int">110</property>
         <property key="pluginToolBarColor" type="string">#bbdefb</property>
         <property key="pluginToolBarTextColor" type="string">#111111</property>
-    </ignition-gui>
+    </gz-gui>
 </plugin>
 <plugin filename="VisualizationCapabilities" name="Visualization Capabilities">
-    <ignition-gui>
+    <gz-gui>
         <property key="x" type="double">0</property>
         <property key="y" type="double">0</property>
         <property key="z" type="double">0</property>
@@ -628,87 +628,29 @@
         <property key="cardMinimumHeight" type="int">130</property>
         <property key="pluginToolBarColor" type="string">#bbdefb</property>
         <property key="pluginToolBarTextColor" type="string">#111111</property>
-    </ignition-gui>
+    </gz-gui>
 </plugin>
 <plugin filename="WorldControl" name="World control">
-    <ignition-gui>
+    <gz-gui>
         <title>World control</title>
+        <property type="bool" key="showTitleBar">false</property>
+        <property type="bool" key="resizable">false</property>
+        <property type="double" key="height">72</property>
+        <property type="double" key="z">1</property>
+
+        <property type="string" key="state">floating</property>
         <anchors target="3D View">
-            <line own="left" target="left"/>
-            <line own="bottom" target="bottom"/>
+        <line own="left" target="left"/>
+        <line own="bottom" target="bottom"/>
         </anchors>
-        <property key="x" type="double">0</property>
-        <property key="y" type="double">896</property>
-        <property key="z" type="double">1</property>
-        <property key="width" type="double">121</property>
-        <property key="height" type="double">72</property>
-        <property key="opacity" type="double">1</property>
-        <property key="enabled" type="bool">true</property>
-        <property key="visible" type="bool">true</property>
-        <property key="state" type="string">floating</property>
-        <property key="baselineOffset" type="double">0</property>
-        <property key="clip" type="bool">false</property>
-        <property key="focus" type="bool">false</property>
-        <property key="activeFocus" type="bool">false</property>
-        <property key="activeFocusOnTab" type="bool">false</property>
-        <property key="rotation" type="double">0</property>
-        <property key="scale" type="double">1</property>
-        <property key="smooth" type="bool">true</property>
-        <property key="antialiasing" type="bool">false</property>
-        <property key="implicitWidth" type="double">0</property>
-        <property key="implicitHeight" type="double">0</property>
-        <property key="availableWidth" type="double">121</property>
-        <property key="availableHeight" type="double">72</property>
-        <property key="padding" type="double">0</property>
-        <property key="topPadding" type="double">0</property>
-        <property key="leftPadding" type="double">0</property>
-        <property key="rightPadding" type="double">0</property>
-        <property key="bottomPadding" type="double">0</property>
-        <property key="spacing" type="double">0</property>
-        <property key="mirrored" type="bool">false</property>
-        <property key="visualFocus" type="bool">false</property>
-        <property key="hovered" type="bool">false</property>
-        <property key="hoverEnabled" type="bool">true</property>
-        <property key="wheelEnabled" type="bool">false</property>
-        <property key="baselineOffset" type="double">0</property>
-        <property key="horizontalPadding" type="double">0</property>
-        <property key="verticalPadding" type="double">0</property>
-        <property key="implicitContentWidth" type="double">0</property>
-        <property key="implicitContentHeight" type="double">0</property>
-        <property key="implicitBackgroundWidth" type="double">0</property>
-        <property key="implicitBackgroundHeight" type="double">0</property>
-        <property key="topInset" type="double">0</property>
-        <property key="leftInset" type="double">0</property>
-        <property key="rightInset" type="double">0</property>
-        <property key="bottomInset" type="double">0</property>
-        <property key="contentWidth" type="double">0</property>
-        <property key="contentHeight" type="double">0</property>
-        <property key="minSize" type="int">50</property>
-        <property key="showDockButton" type="bool">true</property>
-        <property key="showCloseButton" type="bool">true</property>
-        <property key="showCollapseButton" type="bool">true</property>
-        <property key="showTitleBar" type="bool">false</property>
-        <property key="resizable" type="bool">false</property>
-        <property key="standalone" type="bool">false</property>
-        <property key="dockIcon" type="string">▁</property>
-        <property key="collapseIcon" type="string">▴</property>
-        <property key="expandIcon" type="string">▾</property>
-        <property key="floatIcon" type="string">□</property>
-        <property key="closeIcon" type="string">✕</property>
-        <property key="cardBackground" type="string">#00000000</property>
-        <property key="lastHeight" type="int">100</property>
-        <property key="cardMinimumWidth" type="int">121</property>
-        <property key="cardMinimumHeight" type="int">100</property>
-        <property key="pluginToolBarColor" type="string">#bbdefb</property>
-        <property key="pluginToolBarTextColor" type="string">#111111</property>
-    </ignition-gui>
+    </gz-gui>
     <play_pause>true</play_pause>
     <step>true</step>
     <start_paused>true</start_paused>
     <use_event>true</use_event>
 </plugin>
 <plugin filename="WorldStats" name="World stats">
-    <ignition-gui>
+    <gz-gui>
         <title>World stats</title>
         <anchors target="3D View">
             <line own="right" target="right"/>
@@ -778,14 +720,14 @@
         <property key="cardMinimumHeight" type="int">110</property>
         <property key="pluginToolBarColor" type="string">#bbdefb</property>
         <property key="pluginToolBarTextColor" type="string">#111111</property>
-    </ignition-gui>
+    </gz-gui>
     <sim_time>true</sim_time>
     <real_time>true</real_time>
     <real_time_factor>true</real_time_factor>
     <iterations>true</iterations>
 </plugin>
 <plugin filename="Shapes" name="Shapes">
-    <ignition-gui>
+    <gz-gui>
         <property key="x" type="double">0</property>
         <property key="y" type="double">0</property>
         <property key="z" type="double">0</property>
@@ -850,10 +792,10 @@
         <property key="cardMinimumHeight" type="int">100</property>
         <property key="pluginToolBarColor" type="string">#bbdefb</property>
         <property key="pluginToolBarTextColor" type="string">#111111</property>
-    </ignition-gui>
+    </gz-gui>
 </plugin>
 <plugin filename="Lights" name="Lights">
-    <ignition-gui>
+    <gz-gui>
         <property key="x" type="double">250</property>
         <property key="y" type="double">0</property>
         <property key="z" type="double">0</property>
@@ -918,10 +860,10 @@
         <property key="cardMinimumHeight" type="int">100</property>
         <property key="pluginToolBarColor" type="string">#bbdefb</property>
         <property key="pluginToolBarTextColor" type="string">#111111</property>
-    </ignition-gui>
+    </gz-gui>
 </plugin>
 <plugin filename="TransformControl" name="Transform control">
-    <ignition-gui>
+    <gz-gui>
         <property key="x" type="double">0</property>
         <property key="y" type="double">50</property>
         <property key="z" type="double">0</property>
@@ -986,12 +928,12 @@
         <property key="cardMinimumHeight" type="int">100</property>
         <property key="pluginToolBarColor" type="string">#bbdefb</property>
         <property key="pluginToolBarTextColor" type="string">#111111</property>
-    </ignition-gui>
+    </gz-gui>
     <!-- disable legacy features used to connect this plugin to GzScene3D -->
     <legacy>false</legacy>
 </plugin>
 <plugin filename="Screenshot" name="Screenshot">
-    <ignition-gui>
+    <gz-gui>
         <property key="x" type="double">250</property>
         <property key="y" type="double">50</property>
         <property key="z" type="double">0</property>
@@ -1056,10 +998,10 @@
         <property key="cardMinimumHeight" type="int">150</property>
         <property key="pluginToolBarColor" type="string">#bbdefb</property>
         <property key="pluginToolBarTextColor" type="string">#111111</property>
-    </ignition-gui>
+    </gz-gui>
 </plugin>
 <plugin filename="CopyPaste" name="CopyPaste">
-    <ignition-gui>
+    <gz-gui>
         <property key="x" type="double">300</property>
         <property key="y" type="double">50</property>
         <property key="z" type="double">0</property>
@@ -1124,10 +1066,10 @@
         <property key="cardMinimumHeight" type="int">100</property>
         <property key="pluginToolBarColor" type="string">#bbdefb</property>
         <property key="pluginToolBarTextColor" type="string">#111111</property>
-    </ignition-gui>
+    </gz-gui>
 </plugin>
 <plugin filename="Teleop">
-    <ignition-gui>
+    <gz-gui>
         <property key="x" type="double">0</property>
         <property key="y" type="double">0</property>
         <property key="z" type="double">0</property>
@@ -1192,5 +1134,5 @@
         <property key="cardMinimumHeight" type="int">650</property>
         <property key="pluginToolBarColor" type="string">#bbdefb</property>
         <property key="pluginToolBarTextColor" type="string">#111111</property>
-    </ignition-gui>
+    </gz-gui>
 </plugin>

--- a/clearpath_gz/launch/gz_sim.launch.py
+++ b/clearpath_gz/launch/gz_sim.launch.py
@@ -46,7 +46,7 @@ def generate_launch_description():
     # Determine all ros packages that are sourced
     packages_paths = [os.path.join(p, 'share') for p in os.getenv('AMENT_PREFIX_PATH').split(':')]
 
-    # Set ignition resource path to include all sourced ros packages
+    # Set gazebo resource path to include all sourced ros packages
     gz_sim_resource_path = SetEnvironmentVariable(
         name='GZ_SIM_RESOURCE_PATH',
         value=[
@@ -66,6 +66,7 @@ def generate_launch_description():
         launch_arguments=[
             ('gz_args', [LaunchConfiguration('world'),
                          '.sdf',
+                         ' -r',
                          ' -v 4',
                          ' --gui-config ',
                          gui_config])
@@ -73,13 +74,15 @@ def generate_launch_description():
     )
 
     # Clock bridge
-    clock_bridge = Node(package='ros_gz_bridge',
-                        executable='parameter_bridge',
-                        name='clock_bridge',
-                        output='screen',
-                        arguments=[
-                          '/clock@rosgraph_msgs/msg/Clock[ignition.msgs.Clock'
-                        ])
+    clock_bridge = Node(
+        package='ros_gz_bridge',
+        executable='parameter_bridge',
+        name='clock_bridge',
+        output='screen',
+        arguments=[
+            '/clock@rosgraph_msgs/msg/Clock@gz.msgs.Clock'
+        ]
+    )
 
     # Create launch description and add actions
     ld = LaunchDescription(ARGUMENTS)

--- a/clearpath_gz/launch/gz_sim.launch.py
+++ b/clearpath_gz/launch/gz_sim.launch.py
@@ -80,7 +80,7 @@ def generate_launch_description():
         name='clock_bridge',
         output='screen',
         arguments=[
-            '/clock@rosgraph_msgs/msg/Clock@gz.msgs.Clock'
+            '/clock@rosgraph_msgs/msg/Clock[gz.msgs.Clock'
         ]
     )
 

--- a/clearpath_gz/launch/gz_sim.launch.py
+++ b/clearpath_gz/launch/gz_sim.launch.py
@@ -48,7 +48,7 @@ def generate_launch_description():
 
     # Set ignition resource path to include all sourced ros packages
     gz_sim_resource_path = SetEnvironmentVariable(
-        name='IGN_GAZEBO_RESOURCE_PATH',
+        name='GZ_SIM_RESOURCE_PATH',
         value=[
             os.path.join(pkg_clearpath_gz, 'worlds'),
             ':' + ':'.join(packages_paths)])

--- a/clearpath_gz/worlds/warehouse.sdf
+++ b/clearpath_gz/worlds/warehouse.sdf
@@ -5,14 +5,14 @@
       <max_step_size>0.003</max_step_size>
       <real_time_factor>1.0</real_time_factor>
     </physics>
-    <plugin name='ignition::gazebo::systems::Physics' filename='libignition-gazebo-physics-system.so'/>
-    <plugin name='ignition::gazebo::systems::UserCommands' filename='libignition-gazebo-user-commands-system.so'/>
-    <plugin name='ignition::gazebo::systems::SceneBroadcaster' filename='libignition-gazebo-scene-broadcaster-system.so'/>
-    <plugin name="ignition::gazebo::systems::Sensors" filename="libignition-gazebo-sensors-system.so">
+    <plugin name='gz::sim::systems::Physics' filename='libgz-sim-physics-system.so'/>
+    <plugin name='gz::sim::systems::UserCommands' filename='libgz-sim-user-commands-system.so'/>
+    <plugin name='gz::sim::systems::SceneBroadcaster' filename='libgz-sim-scene-broadcaster-system.so'/>
+    <plugin name="gz::sim::systems::Sensors" filename="libgz-sim-sensors-system.so">
       <render_engine>ogre2</render_engine>
     </plugin>
-    <plugin name="ignition::gazebo::systems::Imu" filename="libignition-gazebo-imu-system.so"/>
-    <plugin name="ignition::gazebo::systems::NavSat" filename="libignition-gazebo-navsat-system.so"/>
+    <plugin name="gz::sim::systems::Imu" filename="libgz-sim-imu-system.so"/>
+    <plugin name="gz::sim::systems::NavSat" filename="libgz-sim-navsat-system.so"/>
 
     <scene>
       <ambient>1 1 1 1</ambient>


### PR DESCRIPTION
- Replace `ign` and `ignition` with `gz` where needed.
- Fix `clock_bridge` to be unidirectional instead of bidirectional.
- Fix gazebo resource path envar name