### PR TITLE
Increase the XY scaling of the pipeline world

### DIFF
--- a/clearpath_gz/worlds/pipeline.sdf
+++ b/clearpath_gz/worlds/pipeline.sdf
@@ -60,6 +60,7 @@
               <uri>
                 model://pipeline/inspection_world.dae
               </uri>
+              <scale>2 2 1</scale>
             </mesh>
           </geometry>
         </collision>
@@ -69,6 +70,7 @@
               <uri>
                 model://pipeline/inspection_world.dae
               </uri>
+              <scale>2 2 1</scale>
             </mesh>
           </geometry>
         </visual>
@@ -86,6 +88,7 @@
               <uri>
                 model://pipeline/inspection_water.dae
               </uri>
+              <scale>2 2 1</scale>
             </mesh>
           </geometry>
         </visual>


### PR DESCRIPTION
Make the footprint of the pipeline inspection world bigger; this makes the bridge wide enough to accommodate larger platforms & makes the hills less steep.  There's some minor distortion (e.g. the solar panels are very wide now, the pipes have an elliptical cross-section), but it's generally not too bad. I didn't want to distort the vertical scale relative to the robot, since we ideally want the pipes to be at "eye level" with the platform to simulate inspection jobs.