### PR TITLE
Optionally disable running generators on startup

### DIFF
--- a/clearpath_gz/launch/robot_spawn.launch.py
+++ b/clearpath_gz/launch/robot_spawn.launch.py
@@ -50,7 +50,10 @@ ARGUMENTS = [
                           description='Gazebo World'),
     DeclareLaunchArgument('setup_path',
                           default_value=[EnvironmentVariable('HOME'), '/clearpath/'],
-                          description='Clearpath setup path')
+                          description='Clearpath setup path'),
+    DeclareLaunchArgument('disable_generators', default_value='false',
+                          choices=['true', 'false'],
+                          description='Disable running generators on startup.'),
 ]
 
 for pose_element in ['x', 'y', 'yaw']:
@@ -67,6 +70,7 @@ def launch_setup(context, *args, **kwargs):
     use_sim_time = LaunchConfiguration('use_sim_time')
     x, y, z = LaunchConfiguration('x'), LaunchConfiguration('y'), LaunchConfiguration('z')
     yaw = LaunchConfiguration('yaw')
+    disable_generators_value = LaunchConfiguration('disable_generators').perform(context)
 
     # Parse robot YAML into config
     clearpath_config = ClearpathConfig(os.path.join(
@@ -187,14 +191,17 @@ def launch_setup(context, *args, **kwargs):
         condition=IfCondition(LaunchConfiguration('rviz')),
     )
 
-    return [
-        node_generate_description,
-        event_generate_description,
-        event_generate_semantic_description,
-        event_generate_launch,
-        event_generate_param,
-        rviz
-    ]
+    if disable_generators_value.lower() == 'true':
+        return [group_action_spawn_robot, rviz]
+    else:
+        return [
+            node_generate_description,
+            event_generate_description,
+            event_generate_semantic_description,
+            event_generate_launch,
+            event_generate_param,
+            rviz
+        ]
 
 
 def generate_launch_description():


### PR DESCRIPTION
Right now generators run whenever you spawn a robot. They overwrite your configuration. That can be inconvenient for many reasons.

You can't patch the generated yaml files automatically to add new features. You can't easily debug them either.

This gives you far more control over what's going on. We have multiple robots with multiple arms, which requires some changes to the generated yaml, as well as multiple custom end effectors. It's much easier to generate the base yaml and then add our own code to fill in the gaps, than to constantly have to change our fork of the clearpath generators.