### PR TITLE
Add exception handlers to the generators for Unsupported* exceptions

### DIFF
--- a/clearpath_generator_gz/clearpath_generator_gz/launch/generate_launch
+++ b/clearpath_generator_gz/clearpath_generator_gz/launch/generate_launch
@@ -32,14 +32,26 @@
 # modification, is not permitted without the express permission
 # of Clearpath Robotics.
 
+from clearpath_config.common.types.exception import (
+    UnsupportedAccessoryException,
+    UnsupportedMiddlewareException,
+    UnsupportedPlatformException,
+)
 from clearpath_generator_common.common import BaseGenerator
 from clearpath_generator_gz.launch.generator import GzLaunchGenerator
 
 
 def main():
-    setup_path = BaseGenerator.get_args()
-    glg = GzLaunchGenerator(setup_path)
-    glg.generate()
+    try:
+        setup_path = BaseGenerator.get_args()
+        glg = GzLaunchGenerator(setup_path)
+        glg.generate()
+    except UnsupportedAccessoryException as err:
+        print(f'[ERROR] Unable to generate gz launch: {err}')
+    except UnsupportedMiddlewareException as err:
+        print(f'[ERROR] Unable to generate gz launch: {err}')
+    except UnsupportedPlatformException as err:
+        print(f'[ERROR] Unable to generate gz launch: {err}')
 
 
 if __name__ == '__main__':

--- a/clearpath_generator_gz/clearpath_generator_gz/param/generate_param
+++ b/clearpath_generator_gz/clearpath_generator_gz/param/generate_param
@@ -32,14 +32,26 @@
 # modification, is not permitted without the express permission
 # of Clearpath Robotics.
 
+from clearpath_config.common.types.exception import (
+    UnsupportedAccessoryException,
+    UnsupportedMiddlewareException,
+    UnsupportedPlatformException,
+)
 from clearpath_generator_common.common import BaseGenerator
 from clearpath_generator_gz.param.generator import GzParamGenerator
 
 
 def main():
-    setup_path = BaseGenerator.get_args()
-    gpg = GzParamGenerator(setup_path)
-    gpg.generate()
+    try:
+        setup_path = BaseGenerator.get_args()
+        gpg = GzParamGenerator(setup_path)
+        gpg.generate()
+    except UnsupportedAccessoryException as err:
+        print(f'[ERROR] Unable to generate gz parameters: {err}')
+    except UnsupportedMiddlewareException as err:
+        print(f'[ERROR] Unable to generate gz parameters: {err}')
+    except UnsupportedPlatformException as err:
+        print(f'[ERROR] Unable to generate gz parameters: {err}')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This cleans up the output when the generator fails because of an unsupported configuration, e.g.:
```
[ERROR] Unable to generate bash: Platform w200 is still in-development and not yet supported on jazzy
[ERROR] Unable to generate discovery server: Platform w200 is still in-development and not yet supported on jazzy
[ERROR] Unable to generate description: Platform w200 is still in-development and not yet supported on jazzy
[ERROR] Unable to generate semantic description: Platform w200 is still in-development and not yet supported on jazzy
[ERROR] Unable to generate robot parameters: Platform w200 is still in-development and not yet supported on jazzy
[ERROR] Unable to generate robot launch: Platform w200 is still in-development and not yet supported on jazzy
```

Related changes:
- https://github.com/clearpathrobotics/clearpath_common/pull/192
- https://github.com/clearpathrobotics/clearpath_robot/pull/181
- https://github.com/clearpathrobotics/clearpath_simulator/pull/78