### PR TITLE
Fix the node launch logic for the case when generate is set to false

### DIFF
--- a/clearpath_gz/launch/robot_spawn.launch.py
+++ b/clearpath_gz/launch/robot_spawn.launch.py
@@ -211,7 +211,7 @@ def launch_setup(context, *args, **kwargs):
         rviz
     ]
 
-    if not generate.perform(context):
+    if generate.perform(context) == 'false':
         actions.append(group_action_spawn_robot)
 
     return actions


### PR DESCRIPTION
generate.perform(context) returns the string 'false', so the expression if not generate.perform(context) is effectively if not (str). Since both bool('false') and bool('true')  are always truthy, not bool(str) always evaluates to False, preventing the code block from being executed.