### PR TITLE
Fix spawn group action check

### DIFF
--- a/clearpath_gz/launch/robot_spawn.launch.py
+++ b/clearpath_gz/launch/robot_spawn.launch.py
@@ -205,7 +205,7 @@ def launch_setup(context, *args, **kwargs):
         rviz
     ]
 
-    if not generate.perform(context):
+    if not bool(generate.perform(context)):
         actions.append(group_action_spawn_robot)
 
     return actions


### PR DESCRIPTION
Convert `generate` to a boolean when determining if we need to add the group action

Resolves #82, should be backported to Humble