### PR TITLE
Add explicit gravity & realtime update rate to warehouse world

### DIFF
--- a/clearpath_gz/worlds/warehouse.sdf
+++ b/clearpath_gz/worlds/warehouse.sdf
@@ -4,6 +4,8 @@
     <physics type="ode">
       <max_step_size>0.003</max_step_size>
       <real_time_factor>1.0</real_time_factor>
+      <real_time_update_rate>1000</real_time_update_rate>
+      <gravity>0 0 -9.8</gravity>
     </physics>
     <plugin name='gz::sim::systems::Physics' filename='libgz-sim-physics-system.so'/>
     <plugin name='gz::sim::systems::UserCommands' filename='libgz-sim-user-commands-system.so'/>


### PR DESCRIPTION
All other worlds include these parameters, so to keep things consistent add them to the Warehouse too.