### PR TITLE
Add SeyondLidar support in sensors.py (param generator)

### DIFF
--- a/clearpath_generator_gz/clearpath_generator_gz/param/sensors.py
+++ b/clearpath_generator_gz/clearpath_generator_gz/param/sensors.py
@@ -48,7 +48,7 @@ from clearpath_config.sensors.types.gps import (
 )
 from clearpath_config.sensors.types.imu import BaseIMU, CHRoboticsUM6, Microstrain, RedshiftUM7
 from clearpath_config.sensors.types.lidars_2d import BaseLidar2D, HokuyoUST, SickLMS1XX
-from clearpath_config.sensors.types.lidars_3d import BaseLidar3D, OusterOS1, VelodyneLidar
+from clearpath_config.sensors.types.lidars_3d import BaseLidar3D, OusterOS1, VelodyneLidar, SeyondLidar
 from clearpath_config.sensors.types.sensor import BaseSensor
 
 
@@ -285,6 +285,7 @@ class SensorParam():
         RedshiftUM7.SENSOR_MODEL: ImuParam,
         VelodyneLidar.SENSOR_MODEL: Lidar3dParam,
         OusterOS1.SENSOR_MODEL: Lidar3dParam,
+        SeyondLidar.SENSOR_MODEL: Lidar3dParam,
         Garmin18x.SENSOR_MODEL: GPSParam,
         NovatelSmart6.SENSOR_MODEL: GPSParam,
         NovatelSmart7.SENSOR_MODEL: GPSParam,

--- a/clearpath_generator_gz/clearpath_generator_gz/param/sensors.py
+++ b/clearpath_generator_gz/clearpath_generator_gz/param/sensors.py
@@ -48,7 +48,12 @@ from clearpath_config.sensors.types.gps import (
 )
 from clearpath_config.sensors.types.imu import BaseIMU, CHRoboticsUM6, Microstrain, RedshiftUM7
 from clearpath_config.sensors.types.lidars_2d import BaseLidar2D, HokuyoUST, SickLMS1XX
-from clearpath_config.sensors.types.lidars_3d import BaseLidar3D, OusterOS1, VelodyneLidar, SeyondLidar
+from clearpath_config.sensors.types.lidars_3d import (
+    BaseLidar3D,
+    OusterOS1,
+    SeyondLidar,
+    VelodyneLidar,
+)
 from clearpath_config.sensors.types.sensor import BaseSensor
 
 


### PR DESCRIPTION
The clearpath_config repository contains the SeyondLidar as a 3d lidar:
https://github.com/clearpathrobotics/clearpath_config/blob/jazzy/clearpath_config/sensors/types/lidars_3d.py#L352

Add support for that lidar type as well when generating parameters.