### PR TITLE
Feature: Platform Configuration Class Rework

### DIFF
--- a/clearpath_generator_gz/clearpath_generator_gz/launch/generator.py
+++ b/clearpath_generator_gz/clearpath_generator_gz/launch/generator.py
@@ -33,7 +33,6 @@
 # of Clearpath Robotics.
 import os
 
-from clearpath_config.common.types.platform import Platform
 from clearpath_generator_common.common import LaunchFile
 from clearpath_generator_common.launch.generator import LaunchGenerator
 from clearpath_generator_common.launch.writer import LaunchWriter
@@ -157,41 +156,41 @@ class GzLaunchGenerator(LaunchGenerator):
 
         # Components required for each platform
         self.platform_components = {
-            Platform.J100: self.common_platform_components + [
+            'j100': self.common_platform_components + [
                 self.imu_0_bridge_node,
                 self.imu_filter_arg,
                 self.imu_filter_node,
                 self.gps_0_bridge_node,
             ],
-            Platform.A200: self.common_platform_components,
-            Platform.A300: self.common_platform_components,
-            Platform.DD100: self.common_platform_components + [
+            'a200': self.common_platform_components,
+            'a300': self.common_platform_components,
+            'dd100': self.common_platform_components + [
                 self.imu_0_bridge_node,
                 self.imu_filter_arg,
                 self.imu_filter_node,
             ],
-            Platform.DD150:  self.common_platform_components + [
+            'dd150': self.common_platform_components + [
                 self.imu_0_bridge_node,
                 self.imu_filter_arg,
                 self.imu_filter_node,
             ],
-            Platform.DO100: self.common_platform_components + [
+            'do100': self.common_platform_components + [
                 self.imu_0_bridge_node,
                 self.imu_filter_arg,
                 self.imu_filter_node,
             ],
-            Platform.DO150: self.common_platform_components + [
+            'do150': self.common_platform_components + [
                 self.imu_0_bridge_node,
                 self.imu_filter_arg,
                 self.imu_filter_node,
             ],
-            Platform.GENERIC: self.common_platform_components,
-            Platform.R100: self.common_platform_components + [
+            'generic': self.common_platform_components,
+            'r100': self.common_platform_components + [
                 self.imu_0_bridge_node,
                 self.imu_filter_arg,
                 self.imu_filter_node,
             ],
-            Platform.W200: self.common_platform_components + [
+            'w200': self.common_platform_components + [
                 self.imu_0_bridge_node,
                 self.imu_filter_arg,
                 self.imu_filter_node,

--- a/clearpath_generator_gz/clearpath_generator_gz/param/generator.py
+++ b/clearpath_generator_gz/clearpath_generator_gz/param/generator.py
@@ -34,7 +34,6 @@
 
 import os
 
-from clearpath_config.common.types.platform import Platform
 from clearpath_config.sensors.types.gps import Garmin18x
 from clearpath_config.sensors.types.imu import BaseIMU
 from clearpath_generator_common.param.generator import ParamGenerator
@@ -43,16 +42,16 @@ from clearpath_generator_common.param.platform import PlatformParam
 from clearpath_generator_gz.param.sensors import SensorParam
 
 PLATFORMS = {
-    Platform.A200: {'imu': False, 'gps': False},
-    Platform.A300: {'imu': False, 'gps': False},
-    Platform.J100: {'imu': True, 'gps': True},
-    Platform.DD100: {'imu': True, 'gps': False},
-    Platform.DD150: {'imu': True, 'gps': False},
-    Platform.DO100: {'imu': True, 'gps': False},
-    Platform.DO150: {'imu': True, 'gps': False},
-    Platform.R100: {'imu': True, 'gps': False},
-    Platform.W200: {'imu': True, 'gps': False},
-    Platform.GENERIC: {'imu': False, 'gps': False},
+    'a200': {'imu': False, 'gps': False},
+    'a300': {'imu': False, 'gps': False},
+    'j100': {'imu': True, 'gps': True},
+    'dd100': {'imu': True, 'gps': False},
+    'dd150': {'imu': True, 'gps': False},
+    'do100': {'imu': True, 'gps': False},
+    'do150': {'imu': True, 'gps': False},
+    'r100': {'imu': True, 'gps': False},
+    'w200': {'imu': True, 'gps': False},
+    'generic': {'imu': False, 'gps': False},
 }
 
 


### PR DESCRIPTION
Due to the changes in the clearpath_config https://github.com/clearpathrobotics/clearpath_config/pull/224, there are no longer statically defined platform type enums. Therefore, these will be temporarily held by statically defined strings. These will then be replaced using the same system of dynamically loading platform generators.

Related PRs:
https://github.com/clearpathrobotics/clearpath_config/pull/224
https://github.com/clearpathrobotics/clearpath_common/pull/337
https://github.com/clearpathrobotics/clearpath_robot/pull/332